### PR TITLE
Fix occlusion parameter validation

### DIFF
--- a/src/zennit/attribution.py
+++ b/src/zennit/attribution.py
@@ -505,6 +505,14 @@ class Occlusion(Attributor):
         if not typecheck(stride):
             raise TypeError('Occlusion window must either be an int, or a tuple of ints.')
 
+        def nonpositive(values):
+            return any(v <= 0 for v in (values if isinstance(values, tuple) else (values,)))
+
+        if nonpositive(window):
+            raise ValueError('Occlusion window values must be positive.')
+        if nonpositive(stride):
+            raise ValueError('Occlusion stride values must be positive.')
+
         if occlusion_fn is None:
             occlusion_fn = partial(occlude_independent, fill_fn=torch.zeros_like, invert=False)
         self.occlusion_fn = occlusion_fn

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -268,3 +268,13 @@ def test_occlusion_stride_window_typecheck(argument, container):
     '''Test whether Occlusion raises a TypeError on incorrect types for window and stride.'''
     with pytest.raises(TypeError):
         Occlusion(model=None, **{argument: container})
+
+
+@pytest.mark.parametrize('argument,container', product(
+    ['window', 'stride'],
+    [0, -1, (0,), (1, 0)]
+))
+def test_occlusion_stride_window_valuecheck(argument, container):
+    '''Test whether Occlusion raises a ValueError for non-positive window or stride.'''
+    with pytest.raises(ValueError):
+        Occlusion(model=None, **{argument: container})


### PR DESCRIPTION
## Summary
- validate that occlusion window/stride values are positive
- test error cases for zero or negative occlusion parameters

## Testing
- `pytest tests/test_attribution.py::test_occlusion_stride_window_valuecheck -q`
- `pytest tests/test_attribution.py::test_occlusion_stride_window_typecheck -q`
- `pytest tests/test_attribution.py -k Occlusion -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a510a3648324836a0b82ed56d3fb